### PR TITLE
ci(github-action): update renovatebot/github-action ( v43.0.4 → v43.0…

### DIFF
--- a/.github/workflows/schedule-renovate.yaml
+++ b/.github/workflows/schedule-renovate.yaml
@@ -65,7 +65,7 @@ jobs:
           sudo chown -R 12021:$(id -g) /tmp/renovate
 
       - name: Renovate
-        uses: renovatebot/github-action@a4578d5584ac7a60d0f831537a481de7d00b9260 # v43.0.4
+        uses: renovatebot/github-action@a889a8abcb11ef7feaafaf5e483ea01d4bf7774e # v43.0.5
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
           RENOVATE_ALLOWED_COMMANDS: '["npm run bundle"]'


### PR DESCRIPTION
….5 )

| datasource  | package                   | from    | to      |
| ----------- | ------------------------- | ------- | ------- |
| github-tags | renovatebot/github-action | v43.0.4 | v43.0.5 |