### PR TITLE
ci(github-action): update renovatebot/github-action ( v43.0.6 → v43.0…

### DIFF
--- a/.github/workflows/schedule-renovate.yaml
+++ b/.github/workflows/schedule-renovate.yaml
@@ -66,7 +66,7 @@ jobs:
           sudo chown -R 12021:$(id -g) /tmp/renovate
 
       - name: Renovate
-        uses: renovatebot/github-action@e3c9b63dabe11d616d9a5e9c19064ec6560369c0 # v43.0.6
+        uses: renovatebot/github-action@85b17ebd5abf43d1c34c01bd4c8dbb8d45bbc2c7 # v43.0.7
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
           RENOVATE_ALLOWED_COMMANDS: '["npm run bundle"]'


### PR DESCRIPTION
….7 )

| datasource  | package                   | from    | to      |
| ----------- | ------------------------- | ------- | ------- |
| github-tags | renovatebot/github-action | v43.0.6 | v43.0.7 |