### PR TITLE
ci(github-action): update renovatebot/github-action ( v43.0.11 → v43.…

### DIFF
--- a/.github/workflows/schedule-renovate.yaml
+++ b/.github/workflows/schedule-renovate.yaml
@@ -66,7 +66,7 @@ jobs:
           sudo chown -R 12021:$(id -g) /tmp/renovate
 
       - name: Renovate
-        uses: renovatebot/github-action@6927a58a017ee9ac468a34a5b0d2a9a9bd45cac3 # v43.0.11
+        uses: renovatebot/github-action@f8af9272cd94a4637c29f60dea8731afd3134473 # v43.0.12
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
           RENOVATE_ALLOWED_COMMANDS: '["npm run bundle"]'


### PR DESCRIPTION
…0.12 )

| datasource  | package                   | from     | to       |
| ----------- | ------------------------- | -------- | -------- |
| github-tags | renovatebot/github-action | v43.0.11 | v43.0.12 |