### PR TITLE
ci(github-action): update renovatebot/github-action ( v43.0.12 → v43.…

### DIFF
--- a/.github/workflows/schedule-renovate.yaml
+++ b/.github/workflows/schedule-renovate.yaml
@@ -66,7 +66,7 @@ jobs:
           sudo chown -R 12021:$(id -g) /tmp/renovate
 
       - name: Renovate
-        uses: renovatebot/github-action@f8af9272cd94a4637c29f60dea8731afd3134473 # v43.0.12
+        uses: renovatebot/github-action@9ba84f1ade243f8c2ce5b223df61cf23dc094584 # v43.0.13
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
           RENOVATE_ALLOWED_COMMANDS: '["npm run bundle"]'


### PR DESCRIPTION
…0.13 )

| datasource  | package                   | from     | to       |
| ----------- | ------------------------- | -------- | -------- |
| github-tags | renovatebot/github-action | v43.0.12 | v43.0.13 |