### PR TITLE
ci(github-action): update renovatebot/github-action ( v43.0.17 → v43.…

### DIFF
--- a/.github/workflows/schedule-renovate.yaml
+++ b/.github/workflows/schedule-renovate.yaml
@@ -43,7 +43,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Renovate
-        uses: renovatebot/github-action@70ea19f1b0dc8a9cc7af1b4278f8d3fd9778b577 # v43.0.17
+        uses: renovatebot/github-action@aec779d4f7845f8431ddf403cf9659d4702ddde0 # v43.0.18
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'debug' }}
           RENOVATE_ALLOWED_COMMANDS: '["npm run bundle"]'


### PR DESCRIPTION
…0.18 )

| datasource  | package                   | from     | to       |
| ----------- | ------------------------- | -------- | -------- |
| github-tags | renovatebot/github-action | v43.0.17 | v43.0.18 |